### PR TITLE
inclusão de interceptor

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,11 +23,14 @@ import { UserConfigPage } from '../pages/user-config/user-config';
 import { MainPage } from '../pages/main/main';
 
 import { ExpandableComponent } from '../components/expandable/expandable'
-
+import { TokenInterceptor } from '../providers/interceptor-token';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { IonicStorageModule } from '@ionic/storage';
 import { ConsumesApiProvider } from '../providers/consumes-api/consumes-api';
 import { UserProfilePage } from '../pages/user-profile/user-profile';
 import { AuditServiceProvider } from '../providers/audit-service';
 import { NativeStorage } from '@ionic-native/native-storage';
+
 
 @NgModule({
   declarations: [
@@ -50,7 +53,10 @@ import { NativeStorage } from '@ionic-native/native-storage';
     BrowserModule,
     HttpModule,
     ChartsModule,
-    IonicModule.forRoot(MyApp)
+    IonicModule.forRoot(MyApp),
+    IonicStorageModule.forRoot(),
+    HttpClientModule,
+    
   ],
   bootstrap: [IonicApp],
   entryComponents: [
@@ -72,7 +78,8 @@ import { NativeStorage } from '@ionic-native/native-storage';
   providers: [
     StatusBar,
     SplashScreen,
-    {provide: ErrorHandler, useClass: IonicErrorHandler},
+    { provide: ErrorHandler, useClass: IonicErrorHandler },
+    { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
     AuthServiceProvider,
     AuditServiceProvider,
     ConsumesApiProvider,

--- a/src/pages/dashboard/dashboard.ts
+++ b/src/pages/dashboard/dashboard.ts
@@ -32,9 +32,9 @@ export class  DashboardPage {
   }
 
   ionViewDidLoad() {
-    // this.auditService.search().subscribe(x => {
-    //   console.log('xxxx',x);
-    // });
+    this.auditService.search().subscribe(x => {
+      console.log('xxxx',x);
+    });
     this.nativeStorage.getItem('myitem')
       .then(
         data => console.log(data),

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -42,15 +42,16 @@ export class LoginPage {
     this.authService.login(this.user)
       .then((result) => 
       {
-        this.nativeStorage.setItem('myitem', {property: 'value', anotherProperty: 'anotherValue'})
-          .then(
-            () => console.log('Stored item!'),
-            error => console.error('Error storing item', error)
-          );
+        
         this.loading.dismiss();
         this.data = result;
         User.profile = this.data.profile; 
         localStorage.setItem('token', this.data.token);
+        this.nativeStorage.setItem('token', {token: this.data.token})
+          .then(
+            () => console.log('Stored item!'),
+            error => console.error('Error storing item', error)
+          );
         this.navCtrl.push(MainPage);
       }, (err) => {
         this.loading.dismiss();     

--- a/src/providers/audit-service.ts
+++ b/src/providers/audit-service.ts
@@ -6,13 +6,19 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/observable/throw';
 import { Audit } from '../model/audit';
+import { HttpClient } from '@angular/common/http';
 
 @Injectable()
 export class AuditServiceProvider {
 
-  apiUrl = 'https://api-senai5s.herokuapp.com/';
+  /* Coloquei a url fixa para testar com dados validos */
+  // TODO: Remover url fixa com id, após testes.
+  apiUrl = 'https://api-senai5s.herokuapp.com/audits/1';
 
-  constructor(public http: Http) {}  
+
+  /* Temos que ver o impacto de mudar de http para httpclient.
+   O interceptor só funciona com httpclient. */
+  constructor(public http: HttpClient) {}  
 
     search(): Observable<Audit> {
          return this.http.get(this.apiUrl)
@@ -34,6 +40,6 @@ export class AuditServiceProvider {
 */
     
     private handleError(error: Response) {
-        return Observable.throw(error.json().error || 'Server error');
+        return Observable.throw(error || 'Server error');
     }
 }

--- a/src/providers/interceptor-token.ts
+++ b/src/providers/interceptor-token.ts
@@ -17,7 +17,8 @@ export class TokenInterceptor implements HttpInterceptor {
 
     request = request.clone({
       setHeaders: {
-        Authorization: `Bearer token teste` 
+        /* Adicionar no lugar de teste, o valor do token */
+        Authorization: `Bearer teste` 
       }
     });
 

--- a/src/providers/interceptor-token.ts
+++ b/src/providers/interceptor-token.ts
@@ -1,0 +1,37 @@
+import { AlertController } from 'ionic-angular';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Storage } from '@ionic/storage';
+ 
+import { Observable } from 'rxjs';
+import { _throw } from 'rxjs/observable/throw';
+import { mergeMap } from 'rxjs/operator/mergeMap';
+
+
+@Injectable()
+export class TokenInterceptor implements HttpInterceptor {
+ 
+  constructor(private storage: Storage, private alertCtrl: AlertController) { }
+ 
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    request = request.clone({
+      setHeaders: {
+        Authorization: `Bearer token teste` 
+      }
+    });
+
+    return next.handle(request).do((event: HttpEvent<any>) => {
+        if (event instanceof HttpResponse) {
+            // do stuff with response if you want
+        }
+    },
+    (err: any) => {
+        if (err instanceof HttpErrorResponse) {
+            if (err.status === 401) {
+                // window.location.href = environment.loginUrl;
+            }
+        }
+    });
+  }
+}


### PR DESCRIPTION
@andrefelipeml inclui o interceptor para o mobile também, conforme conversamos.

Tive que alterar de Http para HttpClient, porque pelo o que eu pesquisei, o Http normal não suporta interceptor.

Ainda não consegui testar com o cordova, por tanto dá aquele erro de cordova_not_available. Amanhã nós tentamos achar uma solução pra isso.

O interceptor está funcionando, é só passar o token dai no token-interceptor.ts:
request = request.clone({
      setHeaders: {
        /* Adicionar no lugar de teste, o valor do token */
        Authorization: `Bearer **teste**` 
      }
    });

Podemos nos basear no interceptor do webapp.