### PR TITLE
ajuste nome do metodo

### DIFF
--- a/src/providers/evaluate-service.ts
+++ b/src/providers/evaluate-service.ts
@@ -59,7 +59,7 @@ export class EvaluateServiceProvider {
         return Observable.throw(error || 'Server error');
     }
 
-    updateStatus(status: number, evaluationId: number) {
+    updateEvaluation(status: number, evaluationId: number) {
         return this.http.put(`${this.apiUrl}/${evaluationId}`, {status: status});
     }
 }


### PR DESCRIPTION
No evaluate-service eu não tinha atualizado o nome do método updateEvaluation. Estava dando erro, por chamar um método não existente.